### PR TITLE
Removed "(x86_64, UEFI)" and few "optimizations"

### DIFF
--- a/archiso/grub/grub.cfg
+++ b/archiso/grub/grub.cfg
@@ -30,32 +30,25 @@ timeout_style=menu
 
 # Menu entries
 
-menuentry "CachyOS (x86_64, UEFI)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos' {
+menuentry "CachyOS" --class arch --class gnu-linux --class gnu --class os --id 'cachyos' {
     set gfxpayload=keep
     search --no-floppy --set=root --label %ARCHISO_LABEL%
     linux /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G copytoram=n module_blacklist=nvidia,nvidia_modeset,nvidia_uvm,nvidia_drm,pcspkr nouveau.modeset=1 i915.modeset=1 radeon.modeset=1 nvme_load=yes
     initrd /%INSTALL_DIR%/boot/intel-ucode.img /%INSTALL_DIR%/boot/amd-ucode.img /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img
 }
 
-menuentry "CachyOS (x86_64, UEFI) NVIDIA (latest cards only 900+)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos-nvidia' {
+menuentry "CachyOS with NVIDIA closed-source Driver (latest cards only 900+)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos-nvidia' {
     set gfxpayload=keep
     search --no-floppy --set=root --label %ARCHISO_LABEL%
     linux /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G copytoram=n nvidia nvidia-drm.modeset=1 nouveau.modeset=0 i915.modeset=1 radeon.modeset=1 nvme_load=yes module_blacklist=pcspkr
     initrd /%INSTALL_DIR%/boot/intel-ucode.img /%INSTALL_DIR%/boot/amd-ucode.img /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img
 }
 
-menuentry "CachyOS (x86_64, UEFI) fallback (nomodeset)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos-fallback' {
+menuentry "CachyOS Legacy Hardware (GPU nomodeset)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos-fallback' {
     set gfxpayload=keep
     search --no-floppy --set=root --label %ARCHISO_LABEL%
     linux /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G copytoram=n module_blacklist=nvidia,nvidia_modeset,nvidia_uvm,nvidia_drm nomodeset nvme_load=yes
     initrd /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img
-}
-
-menuentry "CachyOS (copytoram)(x86_64, UEFI)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos-copy-to-ram' {
-    set gfxpayload=keep
-    search --no-floppy --set=root --label %ARCHISO_LABEL%
-    linux /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G module_blacklist=nvidia,nvidia_modeset,nvidia_uvm,nvidia_drm,pcspkr nouveau.modeset=1 i915.modeset=1 radeon.modeset=1 nvme_load=yes
-    initrd /%INSTALL_DIR%/boot/intel-ucode.img /%INSTALL_DIR%/boot/amd-ucode.img /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img
 }
 
 if [ "${grub_platform}" == "efi" ]; then


### PR DESCRIPTION
I think, these Strings can get removed, because the ISO is bootable on x86_64 anyway, and if that machine actually dont have UEFI, its wrong anyway. 

So, a mechanism would be needed, to detect if actualy bios or uefi, or entirely remove it.

(these project is focused to newerish* Hardware anyway)

Same Topic, different Place: Fallback or nomodeset. 99% only for ancient GPUs. Would call it Legacy Hardware. 

Removed Copytoram, because right now dont work anyway (and if needed nowadays, is whole other topic).