### PR TITLE
nvidia: use precompiled nvidia module

### DIFF
--- a/archiso/airootfs/usr/local/bin/removeun
+++ b/archiso/airootfs/usr/local/bin/removeun
@@ -3,8 +3,6 @@
 
 _clean_files() {
 local _files_to_remove=(
-  /etc/modprobe.d/nvidia-utils.conf
-  /etc/modules-load.d/nvidia-utils.conf
   /usr/local/bin/choose-mirror
   /usr/local/bin/prepare-live-desktop.sh
   /usr/local/bin/removeun-online
@@ -45,7 +43,7 @@ local _packages_to_remove=(
   local _check_nvidia_card="$(chwd --is_nvidia_card | grep -q 'NVIDIA card found!'; echo $?)"
   if [[ "${_check_nvidia_card}" -ne 0 ]]; then
     echo "No NVIDIA card detected. Removing nvidia drivers"
-    _packages_to_remove+=(nvidia-dkms nvidia-utils egl-wayland)
+    _packages_to_remove+=(linux-cachyos-nvidia nvidia-utils egl-wayland)
   fi
 
   local xx

--- a/archiso/efiboot/loader/entries/02-archiso-x86_64-linux-nv.conf
+++ b/archiso/efiboot/loader/entries/02-archiso-x86_64-linux-nv.conf
@@ -4,4 +4,4 @@ linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos
 initrd  /%INSTALL_DIR%/boot/intel-ucode.img
 initrd  /%INSTALL_DIR%/boot/amd-ucode.img
 initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img
-options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G nvidia nvidia-drm.modeset=1 nouveau.modeset=0 i915.modeset=1 radeon.modeset=1 nvme_load=yes module_blacklist=pcspkr
+options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G nvidia nvidia-drm.modeset=1 nvidia-drm.fbdev=1 nouveau.modeset=0 i915.modeset=1 radeon.modeset=1 nvme_load=yes module_blacklist=pcspkr

--- a/archiso/grub/grub.cfg
+++ b/archiso/grub/grub.cfg
@@ -66,7 +66,7 @@ menuentry "CachyOS" --class arch --class gnu-linux --class gnu --class os --id '
 
 menuentry "CachyOS with NVIDIA closed-source Driver (latest cards only 900+)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos-nvidia' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos archisobasedir=%INSTALL_DIR% archisodevice=UUID=${ARCHISO_UUID} cow_spacesize=10G copytoram=n nvidia nvidia-drm.modeset=1 nouveau.modeset=0 i915.modeset=1 radeon.modeset=1 nvme_load=yes module_blacklist=pcspkr
+    linux /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos archisobasedir=%INSTALL_DIR% archisodevice=UUID=${ARCHISO_UUID} cow_spacesize=10G copytoram=n nvidia nvidia-drm.modeset=1 nvidia-drm.fbdev=1 nouveau.modeset=0 i915.modeset=1 radeon.modeset=1 nvme_load=yes module_blacklist=pcspkr
     initrd /%INSTALL_DIR%/boot/intel-ucode.img /%INSTALL_DIR%/boot/amd-ucode.img /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img
 }
 

--- a/archiso/packages_gnome.x86_64
+++ b/archiso/packages_gnome.x86_64
@@ -131,6 +131,7 @@ libxinerama
 linux-atm
 linux-cachyos
 linux-cachyos-headers
+linux-cachyos-nvidia
 linux-cachyos-zfs
 linux-firmware
 linux-firmware-marvell
@@ -169,7 +170,6 @@ noto-fonts-cjk
 nss-mdns
 ntfs-3g
 ntp
-nvidia-dkms
 nvidia-utils
 nvme-cli
 octopi

--- a/archiso/packages_kde.x86_64
+++ b/archiso/packages_kde.x86_64
@@ -103,6 +103,7 @@ lightly-git
 linux-atm
 linux-cachyos
 linux-cachyos-headers
+linux-cachyos-nvidia
 linux-cachyos-zfs
 linux-firmware
 linux-firmware-marvell
@@ -140,7 +141,6 @@ noto-fonts-cjk
 nss-mdns
 ntfs-3g
 ntp
-nvidia-dkms
 nvidia-utils
 nvme-cli
 octopi

--- a/archiso/packages_openbox.x86_64
+++ b/archiso/packages_openbox.x86_64
@@ -113,6 +113,7 @@ lightdm-webkit2-greeter
 linux-atm
 linux-cachyos
 linux-cachyos-headers
+linux-cachyos-nvidia
 linux-cachyos-zfs
 linux-firmware
 linux-firmware-marvell
@@ -155,7 +156,6 @@ noto-fonts
 nss-mdns
 ntfs-3g
 ntp
-nvidia-dkms
 nvidia-utils
 nvme-cli
 octopi

--- a/archiso/packages_wayfire.x86_64
+++ b/archiso/packages_wayfire.x86_64
@@ -113,6 +113,7 @@ lightdm
 linux-atm
 linux-cachyos
 linux-cachyos-headers
+linux-cachyos-nvidia
 linux-cachyos-zfs
 linux-firmware
 linux-firmware-marvell
@@ -155,7 +156,6 @@ noto-fonts
 nss-mdns
 ntfs-3g
 ntp
-nvidia-dkms
 nvidia-utils
 nvme-cli
 octopi

--- a/archiso/packages_xfce.x86_64
+++ b/archiso/packages_xfce.x86_64
@@ -116,6 +116,7 @@ lightdm-webkit2-greeter
 linux-atm
 linux-cachyos
 linux-cachyos-headers
+linux-cachyos-nvidia
 linux-cachyos-zfs
 linux-firmware
 linux-firmware-marvell
@@ -158,7 +159,6 @@ noto-fonts
 nss-mdns
 ntfs-3g
 ntp
-nvidia-dkms
 nvidia-utils
 nvme-cli
 octopi

--- a/archiso/syslinux/archiso_sys-linux.cfg
+++ b/archiso/syslinux/archiso_sys-linux.cfg
@@ -17,7 +17,7 @@ ENDTEXT
 MENU LABEL CachyOS NVIDIA (latest cards, x86_64, BIOS)
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos
 INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img
-APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G copytoram=n nvidia nvidia-drm.modeset=1 nouveau.modeset=0 module_blacklist=nouveau,pcspkr i915.modeset=1 radeon.modeset=1 nvme_load=yes
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% cow_spacesize=10G copytoram=n nvidia nvidia-drm.modeset=1 nvidia-drm.fbdev=1 nouveau.modeset=0 module_blacklist=nouveau,pcspkr i915.modeset=1 radeon.modeset=1 nvme_load=yes
 
 # Fallback (nomodeset)
 LABEL cos64fb


### PR DESCRIPTION
This is the preparation for using the precompiled nvidia module instead of relaying on nvidia-dkms.
We are planing to change this behavior with the upcoming release

depends on: https://github.com/CachyOS/chwd-db/pull/26