### PR TITLE
[Draft] Use Chrony instead of systemd-timesyncd

### DIFF
--- a/archiso/airootfs/etc/chrony.conf
+++ b/archiso/airootfs/etc/chrony.conf
@@ -3,7 +3,7 @@
 pool pool.ntp.org iburst maxsources 4 auto_offline
 #Overwrite RTC only if over 30 seconds
 rtcautotrim 30
-#If under 30 Seconds keep track of drifted RTC instead of overwriting the system time
+#If under 30 Seconds keep track of drifted RTC instead of overwriting the RTC
 rtcfile /var/lib/chrony/rtc
 #Keep track of the hardware clocks drift in a file instead of recalculating at boot
 driftfile /var/lib/chrony/drift

--- a/archiso/airootfs/etc/chrony.conf
+++ b/archiso/airootfs/etc/chrony.conf
@@ -1,0 +1,5 @@
+pool pool.ntp.org iburst maxsources 4 auto_offline
+driftfile /var/lib/chrony/drift
+rtcfile /var/lib/chrony/rtc
+rtcautotrim 30
+rtconutc

--- a/archiso/airootfs/etc/chrony.conf
+++ b/archiso/airootfs/etc/chrony.conf
@@ -1,5 +1,13 @@
+#Grab 4 ntp servers from source using a burst behavior. 
+#Auto Offline causes the server to be marked as offline if sending a request fails
 pool pool.ntp.org iburst maxsources 4 auto_offline
-driftfile /var/lib/chrony/drift
-rtcfile /var/lib/chrony/rtc
+#Overwrite RTC only if over 30 seconds
 rtcautotrim 30
+#If under 30 Seconds keep track of drifted RTC instead of overwriting the system time
+rtcfile /var/lib/chrony/rtc
+#Keep track of the hardware clocks drift in a file instead of recalculating at boot
+driftfile /var/lib/chrony/drift
+#Use UTC for hardware clock
 rtconutc
+#Allow chrony to aggressively correct the system clock (not rtc) if over the threshold (0.1) during the first 3 time checks
+makestep 0.1 3

--- a/archiso/airootfs/etc/systemd/system/multi-user.target.wants/chronyd.service
+++ b/archiso/airootfs/etc/systemd/system/multi-user.target.wants/chronyd.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/chronyd.service

--- a/archiso/airootfs/etc/systemd/system/sysinit.target.wants/systemd-time-wait-sync.service
+++ b/archiso/airootfs/etc/systemd/system/sysinit.target.wants/systemd-time-wait-sync.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/systemd-time-wait-sync.service

--- a/archiso/airootfs/etc/systemd/system/sysinit.target.wants/systemd-timesyncd.service
+++ b/archiso/airootfs/etc/systemd/system/sysinit.target.wants/systemd-timesyncd.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/systemd-timesyncd.service

--- a/archiso/packages_kde.x86_64
+++ b/archiso/packages_kde.x86_64
@@ -35,6 +35,7 @@ cachyos-zsh-config
 cantarell-fonts
 capitaine-cursors
 char-white
+chrony
 chwd
 ckbcomp
 clonezilla


### PR DESCRIPTION
This is just an idea i had after jackie was having a stroke due to the system time stuff xD
This uses chrony instead of systemd-timesyncd to sync the time. This should hopefully fix the issue they are having.
This is just a draft for now as some of the options ive added in the config are nigh useless for the live iso.
However even if this is a bad idea for the live ISO i think this might be a good idea for the main system as Chrony is MUCH better at keeping track of time on a system that is offline for long periods of time.

There is also a networkmanager dispatcher script that could be added to allow it to know when the network is reestablished.

Could switch to rtcsync instead of using the RTC file to allow compatibility with hwclock and timedatectl