### PR TITLE
Decrease ParallelDownloads default value

### DIFF
--- a/archiso/airootfs/etc/pacman-more.conf
+++ b/archiso/airootfs/etc/pacman-more.conf
@@ -37,7 +37,7 @@ ILoveCandy
 #CheckSpace
 VerbosePkgLists
 DisableDownloadTimeout
-ParallelDownloads = 10
+ParallelDownloads = 4
 
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.

--- a/archiso/airootfs/etc/pacman.conf
+++ b/archiso/airootfs/etc/pacman.conf
@@ -37,7 +37,7 @@ ILoveCandy
 #CheckSpace
 VerbosePkgLists
 DisableDownloadTimeout
-ParallelDownloads = 10
+ParallelDownloads = 4
 
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.

--- a/archiso/pacman.conf
+++ b/archiso/pacman.conf
@@ -37,7 +37,7 @@ ILoveCandy
 #CheckSpace
 VerbosePkgLists
 DisableDownloadTimeout
-ParallelDownloads = 10
+ParallelDownloads = 4
 
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.


### PR DESCRIPTION
`ParallelDownloads=10` is looks too high value by default for most users who have a regular internet speed.