### PR TITLE
Add bluedevil to ISO packages

### DIFF
--- a/archiso/packages_desktop.x86_64
+++ b/archiso/packages_desktop.x86_64
@@ -9,6 +9,7 @@ base
 bash-completion
 bcachefs-tools
 bind
+bluedevil
 breeze-gtk
 brltty
 btrfs-progs
@@ -83,8 +84,8 @@ linux-cachyos-zfs
 linux-firmware
 linux-firmware-marvell
 lsb-release
-lsscsi
 lsof
+lsscsi
 lvm2
 lynx
 mc


### PR DESCRIPTION
Many people use ISOs not only for installation, but also for system recovery. In this case it has trouble if they have a wireless keyboard or mouse, because there is no convenient way to connect Bluetooth devices in the ISO.