### PR TITLE
grub: make the nvidia entry say 16/20xx instead of just 20xx

### DIFF
--- a/archiso/efiboot/loader/entries/02-archiso-x86_64-linux-nv.conf
+++ b/archiso/efiboot/loader/entries/02-archiso-x86_64-linux-nv.conf
@@ -1,4 +1,4 @@
-title   CachyOS x86_64 UEFI NVIDIA (Turing or newer (20xx))
+title   CachyOS x86_64 UEFI NVIDIA (Turing or newer (16/20xx))
 sort-key B
 linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos
 initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img

--- a/archiso/grub/grub.cfg
+++ b/archiso/grub/grub.cfg
@@ -59,7 +59,7 @@ menuentry "CachyOS" --class arch --class gnu-linux --class gnu --class os --id '
     initrd /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img
 }
 
-menuentry "CachyOS with NVIDIA open-source module (latest cards only 20xx++)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos-nvidia' {
+menuentry "CachyOS with NVIDIA open-source module (latest cards only 16/20xx++)" --class arch --class gnu-linux --class gnu --class os --id 'cachyos-nvidia' {
     set gfxpayload=keep
     linux /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-cachyos archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_spacesize=10G copytoram=auto nvidia nvidia-drm.modeset=1 nvidia-drm.fbdev=1 nouveau.modeset=0 i915.modeset=1 amdgpu.modeset=1 nvme_load=yes module_blacklist=pcspkr
     initrd /%INSTALL_DIR%/boot/x86_64/initramfs-linux-cachyos.img


### PR DESCRIPTION
It is inevitable that a 16 series user that didn't know their 16 series card is also a Turing card, could get confused and unsure of what option to pick (if it hasn't happened already), it may seem obvious that they could pick the regular option if they can't use the Nvidia one, but chances are they would also not know about that either. This would avoid that confusion, and save the user from needing to go out of their way to ask about it, or even worse, just straight up assume Cachy does not support their card and/or that the chosen boot entry would have an effect on the resulting installation.

I'm not entirely sure if the modifications in this PR are correct, so, please double check them.