### PR TITLE
packages: Add plasma-x11-session

### DIFF
--- a/archiso/packages_desktop.x86_64
+++ b/archiso/packages_desktop.x86_64
@@ -138,6 +138,7 @@ plasma-integration
 plasma-nm
 plasma-pa
 plasma-workspace
+plasma-x11-session
 polkit
 polkit-kde-agent
 power-profiles-daemon


### PR DESCRIPTION
Arch have split it into separate package, and since we're using it by default in ISO environment (https://github.com/CachyOS/CachyOS-Live-ISO/blob/master/archiso/airootfs/etc/sddm.conf.d/autologin.conf#L3)  we must be sure that it's installed.