### PR TITLE
Remove bypass of package signatures on ISO build

### DIFF
--- a/archiso/pacman.conf
+++ b/archiso/pacman.conf
@@ -74,11 +74,6 @@ LocalFileSigLevel = Optional
 # repo name header and Include lines. You can add preferred servers immediately
 # after the header, and they will be used before the default mirrors.
 [cachyos]
-# Yeah, that's dumb, but we have to do it for nvidia-module-extractor hook,
-# since mkarchiso doesn't import the keys inside rootfs for cachyos repo before
-# creating squashfs. The right solution here would be to find a way to import
-# the keys properly.
-SigLevel = Never
 Server = https://mirror.cachyos.org/repo/$arch/$repo
 
 #[core-testing]


### PR DESCRIPTION
It was old workaround for module-extractor and we definitely shouldn’t leave it as is for security reasons.

Depends on: https://github.com/CachyOS/CachyOS-PKGBUILDS/pull/778