### PR TITLE
Integrate NVIDIA module extractor

### DIFF
--- a/archiso/airootfs/etc/pacman.d/hooks/nvidia-module-extractor.hook
+++ b/archiso/airootfs/etc/pacman.d/hooks/nvidia-module-extractor.hook
@@ -1,0 +1,11 @@
+# remove from airootfs!
+[Trigger]
+Operation = Upgrade
+Operation = Install
+Type = Package
+Target = *
+
+[Action]
+Description = Extracting NVIDIA modules in separate directory...
+When = PostTransaction
+Exec = /usr/share/libalpm/scripts/nvidia-module-extractor

--- a/archiso/airootfs/usr/share/libalpm/scripts/nvidia-module-extractor
+++ b/archiso/airootfs/usr/share/libalpm/scripts/nvidia-module-extractor
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Copyright (C) 2025 CachyOS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+function error() {
+    echo "Error: $*" >&2
+}
+function die() {
+    error "$@"
+    exit 1
+}
+
+function extract_package_modules() {
+    local pkgname="$1"
+
+    if ! pacman -S "${pacman_opts[@]}" -sq "^$pkgname\$" &>/dev/null; then
+        error "Package $pkgname is not found in any repository."
+        error "Make sure your pacman configuration is correct."
+        return 1
+    fi
+
+    echo "Downloading $pkgname package..."
+
+    local url="$(pacman -Swd "${pacman_opts[@]}" --print "$pkgname")"
+    curl -SOL --retry 5 --output-dir "$tmp" "$url" || {
+        error "Failed to download $pkgname package"
+        return 1
+    }
+
+    cd "$tmp"
+    echo "Unpacking $pkgname package..."
+    tar -xf "$pkgname"-*.pkg.tar.zst || {
+        error "Failed to extract package tarball"
+        return 1
+    }
+
+    if [ ! -e "$tmp/usr/lib/modules" ]; then
+        error "Package $pkgname doesn't contain any kernel modules"
+        return 1
+    fi
+
+    mkdir -p "/usr/share/modules/$pkgname"
+    cp -v "$tmp/usr/lib/modules"/*/*.ko.zst "/usr/share/modules/$pkgname/"
+
+    echo "Extracting modules for $pkgname is complete"
+    return 0
+}
+
+function main() {
+    local tmp="$(mktemp --suffix="-extractor" -d)"
+
+    # Import cachyos repository key
+    local gpg_dir="$tmp/gnupg"
+    local pacman_conf="$tmp/pacman.conf"
+    mkdir -p "$gpg_dir"
+
+    cat << 'EOF' >"$pacman_conf"
+[options]
+DisableDownloadTimeout
+Architecture = auto
+
+[cachyos]
+Include = /etc/pacman.d/cachyos-mirrorlist
+EOF
+
+    local -a pacman_opts=(
+       --gpgdir "$gpg_dir"
+       --config "$pacman_conf"
+    )
+
+    mv -f /etc/resolv.conf /etc/resolv.conf.bak
+    echo "nameserver 1.1.1.1" > /etc/resolv.conf
+
+    if ! (
+        pacman-key "${pacman_opts[@]}" --init
+        pacman-key "${pacman_opts[@]}" --recv-keys F3B607488DB35A47 --keyserver keyserver.ubuntu.com
+        pacman-key "${pacman_opts[@]}" --lsign-key F3B607488DB35A47
+    ); then
+        die "Failed to import GPG key for cachyos repository"
+    fi
+
+    for kernel in $(pacman "${pacman_opts[@]}" -Qqs "^linux-cachyos"); do
+
+        case "$kernel" in
+            *-nvidia-open|*-nvidia|*-headers|*-zfs|*-dbg);;
+            *)
+               extract_package_modules "${kernel}-nvidia"
+               extract_package_modules "${kernel}-nvidia-open"
+               ;;
+        esac
+    done
+
+    mv -f /etc/resolv.conf.bak /etc/resolv.conf
+    rm -rf -- "$tmp"
+}
+
+main

--- a/archiso/packages_desktop.x86_64
+++ b/archiso/packages_desktop.x86_64
@@ -114,7 +114,6 @@ nss-mdns
 ntfs-3g
 ntp
 nvidia-utils
-nvidia-module-extractor
 nvme-cli
 occt
 open-iscsi

--- a/archiso/profiledef.sh
+++ b/archiso/profiledef.sh
@@ -33,4 +33,5 @@ file_permissions=(
   ["/usr/local/bin/removeun-online"]="0:0:755"
   ["/usr/local/bin/prepare-live-desktop.sh"]="0:0:755"
   ["/usr/local/bin/nvidia-module-loader"]="0:0:755"
+  ["/usr/share/libalpm/scripts/nvidia-module-extractor"]="0:0:755"
 )


### PR DESCRIPTION
This is what I had to do initially, but I didn’t know about such a possibility in archiso before. This also allows us not to hardcode names of kernels in the hook, instead relying on the ISO environment.