### PR TITLE
Update profiledef.sh bootmodes 

### DIFF
--- a/archiso/profiledef.sh
+++ b/archiso/profiledef.sh
@@ -9,9 +9,9 @@ iso_version="$(date --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y.%m.%d)"
 install_dir="arch"
 buildmodes=('iso')
 ## GRUB
-bootmodes=('bios.syslinux.mbr' 'bios.syslinux.eltorito' 'uefi-x64.grub.esp' 'uefi-x64.grub.eltorito')
+bootmodes=('bios.syslinux' 'uefi.grub')
 ## systemd-boot
-#bootmodes=('bios.syslinux.mbr' 'bios.syslinux.eltorito' 'uefi-x64.systemd-boot.esp' 'uefi-x64.systemd-boot.eltorito')
+#bootmodes=('bios.syslinux' 'uefi.systemd-boot')
 arch="x86_64"
 pacman_conf="pacman.conf"
 airootfs_image_type="squashfs"


### PR DESCRIPTION
Replace deprecated values of bootmodes that cause buildiso to fail.

( Reference docs: https://github.com/archlinux/archiso/blob/master/docs/README.profile.rst )

This closes #62.