### PR TITLE
Add automatic testing for live environment and installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,17 @@ jobs:
           name: cachyos-desktop-linux-${{ steps.date.outputs.builddate }}
           path: out/desktop/*
   quicktest:
-    name: Testing
+    name: Testing (${{ matrix.bootloader }})
     runs-on: ubuntu-latest
     needs: build
     container:
       image: archlinux:base-devel
       options: --privileged
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        bootloader: [grub, systemd-boot, refind, limine]
     steps:
       - name: Clone CachyOS-Live-ISO
         id: clone
@@ -102,11 +107,12 @@ jobs:
           QT_TESTCASES_DIR: "./testcases"
           QUICKEMU_DISPLAY: "none"
           QUICKEMU_VM_DIR: "./machines"
+          TEST_BOOTLOADER: "${{ matrix.bootloader }}"
 
       - name: Upload results to artifacts
         id: upload-results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cachyos-desktop-linux-results-${{needs.build.outputs.builddate}}
+          name: cachyos-desktop-linux-results-${{needs.build.outputs.builddate}}-${{ matrix.bootloader }}
           path: results/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           name: cachyos-desktop-linux-${{ steps.date.outputs.builddate }}
           path: out/desktop/*
   quicktest:
-    name: Testing (${{ matrix.bootloader }})
+    name: Testing (${{ matrix.bootloader }} / ${{ matrix.filesystem }})
     runs-on: ubuntu-latest
     needs: build
     container:
@@ -56,6 +56,7 @@ jobs:
       max-parallel: 4
       matrix:
         bootloader: [grub, systemd-boot, refind, limine]
+        filesystem: [btrfs, xfs, ext4, f2fs, zfs]
     steps:
       - name: Clone CachyOS-Live-ISO
         id: clone
@@ -108,11 +109,12 @@ jobs:
           QUICKEMU_DISPLAY: "none"
           QUICKEMU_VM_DIR: "./machines"
           TEST_BOOTLOADER: "${{ matrix.bootloader }}"
+          TEST_FILESYSTEM: "${{ matrix.filesystem }}"
 
       - name: Upload results to artifacts
         id: upload-results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cachyos-desktop-linux-results-${{needs.build.outputs.builddate}}-${{ matrix.bootloader }}
+          name: cachyos-desktop-linux-results-${{needs.build.outputs.builddate}}-${{ matrix.bootloader }}-${{ matrix.filesystem }}
           path: results/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
       image: archlinux:base-devel
       options: --privileged
     name: Build
+    outputs:
+      builddate: ${{ steps.date.outputs.builddate }}
     steps:
       - name: Get build date
         id: date
@@ -42,3 +44,69 @@ jobs:
         with:
           name: cachyos-desktop-linux-${{ steps.date.outputs.builddate }}
           path: out/desktop/*
+  quicktest:
+    name: Testing
+    runs-on: ubuntu-latest
+    needs: build
+    container:
+      image: archlinux:base-devel
+      options: --privileged
+    steps:
+      - name: Clone CachyOS-Live-ISO
+        id: clone
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        id: dependencies
+        run: |
+          pacman -Syu --noconfirm git ffmpeg imagemagick tesseract-data-eng qemu-desktop
+
+      - name: Create build user
+        id: user
+        run: |
+          useradd builder -m
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          chmod -R a+rw .
+
+      - name: Build quickemu
+        id: quickemu
+        run: |
+          sudo -u builder git clone https://aur.archlinux.org/quickemu.git
+          cd quickemu
+          sudo -H -E -u builder makepkg --syncdeps --noconfirm
+          pacman -U --noconfirm quickemu*.pkg.tar.zst
+          cd ..
+
+      - name: Clone quicktest
+        id: clone-quicktest
+        uses: actions/checkout@v6
+        with:
+          repository: 'quickemu-project/quicktest'
+          path: 'quicktest'
+
+      - name: Download ISO
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          path: machines/cachyos-dailylive
+          merge-multiple: true
+
+      - name: Run quicktest
+        id: quicktest
+        run: |
+          ./quicktest/quicktest test_install_calamares cachyos dailylive
+        env:
+          QT_NOTIFY: "false"
+          QT_OPEN_RESULTS: "false"
+          QT_QUICKGET_SKIP: "true"
+          QT_TESTCASES_DIR: "./testcases"
+          QUICKEMU_DISPLAY: "none"
+          QUICKEMU_VM_DIR: "./machines"
+
+      - name: Upload results to artifacts
+        id: upload-results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cachyos-desktop-linux-results-${{needs.build.outputs.builddate}}
+          path: results/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Desktop ISO
-on: push
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,9 @@ jobs:
         id: build
         run: |
           ./buildiso.sh
+      - name: Upload ISO to artifacts
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: cachyos-desktop-linux-${{ steps.date.outputs.builddate }}
+          path: out/desktop/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Desktop ISO
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+      options: --privileged
+    name: Build
+    steps:
+      - name: Get build date
+        id: date
+        run: |
+          echo "builddate=$(date +'%y%m%d')" >> $GITHUB_OUTPUT
+
+      - name: Clone CachyOS-Live-ISO
+        id: clone
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Add CachyOS keyring
+        id: keyring
+        run: |
+          pacman-key --init
+          pacman-key --recv-keys F3B607488DB35A47 --keyserver keyserver.ubuntu.com
+          pacman-key --lsign-key F3B607488DB35A47
+
+      - name: Install dependencies
+        id: dependencies
+        run: |
+          sudo pacman -Syu --noconfirm archiso mkinitcpio-archiso squashfs-tools grub
+
+      - name: Build ISO (${{ steps.date.outputs.builddate }})
+        id: build
+        run: |
+          ./buildiso.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Desktop ISO
 on: push
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/machines/cachyos-dailylive.conf
+++ b/machines/cachyos-dailylive.conf
@@ -1,0 +1,3 @@
+guest_os="linux"
+disk_img="cachyos-dailylive/disk.qcow2"
+iso="$(realpath "$(find -name "*.iso" | head -n1)")"

--- a/testcases/cachyos/dailylive/i18n/en_US
+++ b/testcases/cachyos/dailylive/i18n/en_US
@@ -1,0 +1,58 @@
+# CachyOS Calamares install
+
+# Language
+
+TESSERACT_LANG="eng"
+
+# GRUB
+
+text_console_gnu_grub="GNU GRUB"
+
+# Initial splash
+
+text_console_prompt_welcome="Welcome to CachyOS"
+text_console_prompt_login="localhost login"
+
+# Calamares Welcome
+
+text_calamares_welcome="Welcome to the CachyOS installer"
+
+# Calamares Language
+
+text_calamares_language="The system language will be set to"
+
+# Calamares Keyboard
+
+text_calamares_keyboard="Keyboard model"
+
+# Calamares Bootloader
+
+text_calamares_bootloader="Limine"
+
+# Calamares Partitions
+
+text_calamares_partitions="Select storage device"
+
+# Calamares Desktop
+
+text_calamares_desktop="Plasma Desktop"
+
+# Calamares Packages
+
+text_calamares_packages="Additional packages"
+
+# Calamares Users
+
+text_calamares_users="What name do you want to use to log in?"
+
+# Calamares Summary
+
+text_calamares_summary="This is an overview"
+
+# Calamares Install
+
+text_calamares_install="Continue with Installation"
+
+# Calamares Finished
+
+text_calamares_finished="All done"

--- a/testcases/cachyos/dailylive/test_install_calamares
+++ b/testcases/cachyos/dailylive/test_install_calamares
@@ -11,6 +11,28 @@ function test_setup() {
     test_password="ILoveCandy"
 }
 
+function qt_wait_else() {
+    local test_name="$1"
+    local fallback="$2"
+    local text="$3"
+    local retries=$4
+    local interval=$5
+
+    for c in $( seq 1 $retries ); do
+        qt_echo "🔁 $c / $retries «$text» "
+        qt_screenshot_ppm "$test_name"
+        # We only ever OCR the most recent image, so we just send the text name and the screenshot count
+        if qt_search_screenshot "$test_name" "$text"; then
+            return 0
+        fi
+        qt_wait_for_seconds "$interval"
+    done
+
+    "$fallback" "$test_name"
+
+    qt_test_fail "Coulnd't find text «$text» in screenshot «$QT_SCREENSHOT_COUNT» after $retries retries"
+}
+
 function test_post_boot_grub() {
     qt_wait_for_seconds 5
     qt_wait_for_text "$FUNCNAME" "GNU GRUB" 3 5
@@ -144,8 +166,14 @@ function test_calamares_install() {
     qt_screenshot_ppm "$FUNCNAME"
 }
 
+function test_calamares_failed() {
+    qt_send_key_combo "spc"
+    qt_wait_for_seconds 2
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
 function test_calamares_finished() {
-    qt_wait_for_text "$FUNCNAME" "$text_calamares_finished" 30 60
+    qt_wait_else "$FUNCNAME" "test_calamares_failed" "$text_calamares_finished" 30 60
     qt_send_key_combo "spc"
     qt_screenshot_ppm "$FUNCNAME"
 }

--- a/testcases/cachyos/dailylive/test_install_calamares
+++ b/testcases/cachyos/dailylive/test_install_calamares
@@ -62,8 +62,19 @@ function test_calamares_keyboard() {
 
 function test_calamares_bootloader() {
     qt_wait_for_text "$FUNCNAME" "$text_calamares_bootloader" 10 5
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
     qt_send_key_combo "spc"
+
+    for ((i=0; i < bootloader_index; i++)); do
+        qt_send_key_combo "down"
+    done
+
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
     qt_screenshot_ppm "$FUNCNAME"
+    qt_send_key_combo "spc"
 }
 
 function test_calamares_partitions() {
@@ -133,7 +144,30 @@ function test_power_off_vm() {
     qt_poweroff_vm
 }
 
+function test_input_validation() {
+    local -Ar bootloaders=(
+        ["grub"]="0"
+        ["refind"]="1"
+        ["refind-ai"]="2"
+        ["systemd-boot"]="3"
+        ["limine"]="4"
+    )
+
+    local bootloader="${TEST_BOOTLOADER:-Limine}"
+    local -g bootloader_index="${bootloaders[$bootloader]}"
+
+    if [ -z "$bootloader_index" ]; then
+        qt_echo "🚨 Unknown bootloader passed: $bootloader"
+        exit 1
+    else
+        qt_echo "✅ Selected bootloader is $bootloader ($bootloader_index)"
+    fi
+
+    qt_echo "✅ Validation passed"
+}
+
 function test_install_calamares() {
+    test_input_validation
     test_setup
     test_post_boot_grub
     test_launch_calamares

--- a/testcases/cachyos/dailylive/test_install_calamares
+++ b/testcases/cachyos/dailylive/test_install_calamares
@@ -83,13 +83,23 @@ function test_calamares_partitions() {
     qt_send_key_combo "tab"
     qt_send_key_combo "tab"
     qt_send_key_combo "spc"
-    qt_send_key_combo "shift-tab"
-    qt_send_key_combo "shift-tab"
-    qt_send_key_combo "shift-tab"
-    qt_send_key_combo "shift-tab"
-    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "tab"
     qt_send_key_combo "spc"
+
+    for ((i=0; i < filesystem_index; i++)); do
+        qt_send_key_combo "down"
+    done
+
+    qt_send_key "enter"
+    qt_wait_for_seconds 2
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
     qt_screenshot_ppm "$FUNCNAME"
+    qt_send_key_combo "spc"
 }
 
 function test_calamares_desktop() {
@@ -153,6 +163,14 @@ function test_input_validation() {
         ["limine"]="4"
     )
 
+    local -Ar filesystems=(
+        ["btrfs"]="0"
+        ["xfs"]="1"
+        ["ext4"]="2"
+        ["f2fs"]="3"
+        ["zfs"]="4"
+    )
+
     local bootloader="${TEST_BOOTLOADER:-Limine}"
     local -g bootloader_index="${bootloaders[$bootloader]}"
 
@@ -161,6 +179,16 @@ function test_input_validation() {
         exit 1
     else
         qt_echo "✅ Selected bootloader is $bootloader ($bootloader_index)"
+    fi
+
+    local filesystem="${TEST_FILESYSTEM:-btrfs}"
+    local -g filesystem_index="${filesystems[$filesystem]}"
+
+    if [ -z "$filesystem_index" ]; then
+        qt_echo "🚨 Unknown filesystem passed: $filesystem"
+        exit 1
+    else
+        qt_echo "✅ Selected filesystem is $filesystem ($filesystem_index)"
     fi
 
     qt_echo "✅ Validation passed"

--- a/testcases/cachyos/dailylive/test_install_calamares
+++ b/testcases/cachyos/dailylive/test_install_calamares
@@ -1,0 +1,155 @@
+# Install CachyOS daily live
+
+function test_description() {
+    cat << EOF
+Do a clean install of CachyOS using all the defaults
+EOF
+}
+
+function test_setup() {
+    test_user="cachyos"
+    test_password="ILoveCandy"
+}
+
+function test_post_boot_grub() {
+    qt_wait_for_seconds 5
+    qt_wait_for_text "$FUNCNAME" "GNU GRUB" 3 5
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_send_key "return"
+}
+
+function test_launch_calamares() {
+    qt_wait_for_text "$FUNCNAME" "Welcome to CachyOS!" 3 60
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_send_key_combo "alt-f2"
+    qt_wait_for_seconds 2
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_send_string_tab "CALAMARES_SKIP_GEOIP=1 sudo -E dbus-launch calamares -D6"
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_wait_for_text "$FUNCNAME" "CALAMARES_SKIP_GEOIP=1 sudo -E dbus-launch calamares -D6" 3 3
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key "return"
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_wait_for_seconds 20
+}
+
+function test_calamares_welcome() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_welcome" 10 5
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "spc"
+}
+
+function test_calamares_location() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_language" 10 5
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "spc"
+}
+
+function test_calamares_keyboard() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_keyboard" 10 5
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_calamares_bootloader() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_bootloader" 10 5
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_calamares_partitions() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_partitions" 10 5
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "spc"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "shift-tab"
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_calamares_desktop() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_desktop" 10 5
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_calamares_packages() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_packages" 10 5
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_calamares_users() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_users" 10 5
+    qt_send_string_tab "$test_user"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_string_tab "$test_password"
+    qt_send_string_tab "$test_password"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "tab"
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_calamares_summary() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_summary" 10 5
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_calamares_install() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_install" 10 30
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_calamares_finished() {
+    qt_wait_for_text "$FUNCNAME" "$text_calamares_finished" 30 60
+    qt_send_key_combo "spc"
+    qt_screenshot_ppm "$FUNCNAME"
+}
+
+function test_power_off_vm() {
+    qt_poweroff_vm
+}
+
+function test_install_calamares() {
+    test_setup
+    test_post_boot_grub
+    test_launch_calamares
+    test_calamares_welcome
+    test_calamares_location
+    test_calamares_keyboard
+    test_calamares_bootloader
+    test_calamares_partitions
+    test_calamares_desktop
+    test_calamares_packages
+    test_calamares_users
+    test_calamares_summary
+    test_calamares_install
+    test_calamares_finished
+    test_power_off_vm
+}
+
+test_description
+

--- a/testcases/cachyos/dailylive/test_no_test_gather_screenshots_and_text_only
+++ b/testcases/cachyos/dailylive/test_no_test_gather_screenshots_and_text_only
@@ -1,0 +1,39 @@
+# This test merely loops forever, taking a screenshot when asked
+
+function test_description() {
+    cat << EOF
+This test merely loops forever, taking a screenshot when asked
+The goal of this is for you to manually run the distro or release you wish to test,
+and press [return] in the terminal window, whenever you wish to take a screenshot.
+This script will take a screenshot, and then wait for you to press [return] again.
+After taking the screeshot, it will run tesseract to turn the image into text.
+This is useful if you wish to gather screenshots and text for a new distro, or
+release, or language. You can then use this text to create a new test script.
+EOF
+}
+
+function test_setup() {
+    # Settings we choose to override here
+    QT_KEEP_SCREENSHOTS=true
+    QT_KEEP_TESSERACT_TEXT=true
+
+    # Set the language to test
+    # Be sure to install the relavent tesseract language pack
+    # e.g. tesseract-ocr-fra
+    TESSERACT_LANG="eng"
+}
+
+function test_loop_gathering_screenshots_and_text() {
+    qt_screenshot_ppm notest
+    qt_ocr_only notest
+    qt_wait_for_host_keypress
+}
+
+function test_no_test_gather_screenshots_and_text_only() {
+    # Loop forever
+    while true; do
+        test_loop_gathering_screenshots_and_text
+    done
+}
+
+test_description

--- a/testcases/keymaps/en_US
+++ b/testcases/keymaps/en_US
@@ -1,0 +1,55 @@
+# English (US) key mappings for sendkey
+
+KEYS+=(
+  ["\`"]=grave
+  ["~"]=shift-grave
+  ["!"]=shift-1
+  ["@"]=shift-2
+  ["#"]=shift-3
+  ["$"]=shift-4
+  ["%"]=shift-5
+  ["^"]=shift-6
+  ["&"]=shift-7
+  ["*"]=shift-8
+  ["("]=shift-9
+  [")"]=shift-0
+  ["-"]=minus
+  ["_"]=shift-minus
+  ["="]=equal
+  ["+"]=shift-equal
+  ["["]=bracketleft
+  ["{"]=shift-bracketleft
+  ["]"]=bracketright
+  ["}"]=shift-bracketright
+  ["\\"]=backslash
+  ["|"]=shift-backslash
+  [";"]=semicolon
+  [":"]=shift-semicolon
+  ["'"]=apostrophe
+  ["@"]=shift-apostrophe
+  [","]=comma
+  ["<"]=shift-comma
+  [">"]=shift-period
+  ["/"]=slash
+  ["?"]=shift-slash
+  ["."]=dot
+  [" "]=spc
+  ["enter"]=ret
+  ["return"]=ret
+  ["escape"]=esc
+  ["esc"]=esc
+  ["tab"]=tab
+)
+
+for letter in {a..z}; do
+  KEYS+=(
+    ["$letter"]=$letter
+    ["${letter^^}"]=shift-$letter
+  )
+done
+
+for number in {0..9}; do
+  KEYS+=(
+    ["$number"]=$number
+  )
+done


### PR DESCRIPTION
This adds automatic testing of ISO environment and system installation process through calamares using the quicktest project. The main motivation for this is to make maintaince easier, speed up the process of releasing new ISOs and improve quality of testing as it allows to test many configurations at once for each change.

It works pretty simple: Testing takes place in QEMU virtual machine, with which quicktest communicate via socket, through which predescribed actions are transmitted - keystroke sequences, which are described as simple shell script in the `testcases` directory. Control of the process is carried out by sequential capture of screenshots and it analysis using OCR (tesseract). The main limitation here is that you can’t pass input with a "virtual" mouse, but usually keyboard control is enough to check many things like installation process.

At the end, result of installation timelapse is uploaded into the artifacts along with ISO.

Of course, this does not allow us to identify in advance all hardware-specific issues (at least now, if we had our own runners, we could test and it just by passthrough GPU and other things in VM), but at least it gives a good QA on changes in calamares. 

Some future work:

- [ ] Add tests for BIOS installation (right now it's UEFI only)
- [ ] Add tests for full disk encryption
- [ ] Add installation tests via New-Cli-Installer
- [ ] Integrate tests with calamares tree? Can be useful when developing and bisecting problematic changes before merging.