### PR TITLE
Fix tests

### DIFF
--- a/testcases/cachyos/dailylive/test_install_calamares
+++ b/testcases/cachyos/dailylive/test_install_calamares
@@ -48,7 +48,7 @@ function test_launch_calamares() {
     qt_screenshot_ppm "$FUNCNAME"
     qt_send_string_tab "CALAMARES_SKIP_GEOIP=1 sudo -E dbus-launch calamares -D6"
     qt_screenshot_ppm "$FUNCNAME"
-    qt_wait_for_text "$FUNCNAME" "CALAMARES_SKIP_GEOIP=1 sudo -E dbus-launch calamares -D6" 3 3
+    qt_wait_for_seconds 1
     qt_screenshot_ppm "$FUNCNAME"
     qt_send_key_combo "tab"
     qt_send_key_combo "tab"

--- a/testcases/cachyos/dailylive/test_install_calamares
+++ b/testcases/cachyos/dailylive/test_install_calamares
@@ -167,6 +167,7 @@ function test_calamares_install() {
 }
 
 function test_calamares_failed() {
+    qt_send_key_combo "tab"
     qt_send_key_combo "spc"
     qt_wait_for_seconds 2
     qt_screenshot_ppm "$FUNCNAME"

--- a/testcases/cachyos/dailylive/test_install_calamares
+++ b/testcases/cachyos/dailylive/test_install_calamares
@@ -46,7 +46,7 @@ function test_launch_calamares() {
     qt_send_key_combo "alt-f2"
     qt_wait_for_seconds 2
     qt_screenshot_ppm "$FUNCNAME"
-    qt_send_string_tab "CALAMARES_SKIP_GEOIP=1 sudo -E dbus-launch calamares -D6"
+    qt_send_string_tab "CALAMARES_SKIP_GEOIP=1 sudo -E systemd-inhibit dbus-launch calamares -D6"
     qt_screenshot_ppm "$FUNCNAME"
     qt_wait_for_seconds 1
     qt_screenshot_ppm "$FUNCNAME"


### PR DESCRIPTION
For some reason, this does not have right match anymore, and the next step will already fail if calamares has not started for some reason, so it's fine to replace it with simple timer.