### PR TITLE
Remove unnecessary comments from target pacman configuration

### DIFF
--- a/archiso/airootfs/etc/pacman-more.conf
+++ b/archiso/airootfs/etc/pacman-more.conf
@@ -70,35 +70,6 @@ LocalFileSigLevel = Optional
 # uncommented to enable the repo.
 #
 
-# cachyos repos
-
-#<disabled_znver4>[cachyos-znver4]
-#<disabled_znver4>Include = /etc/pacman.d/cachyos-v4-mirrorlist
-
-#<disabled_znver4>[cachyos-core-znver4]
-#<disabled_znver4>Include = /etc/pacman.d/cachyos-v4-mirrorlist
-
-#<disabled_znver4>[cachyos-extra-znver4]
-#<disabled_znver4>Include = /etc/pacman.d/cachyos-v4-mirrorlist
-
-#<disabled_v4>[cachyos-v4]
-#<disabled_v4>Include = /etc/pacman.d/cachyos-v4-mirrorlist
-
-#<disabled_v4>[cachyos-core-v4]
-#<disabled_v4>Include = /etc/pacman.d/cachyos-v4-mirrorlist
-
-#<disabled_v4>[cachyos-extra-v4]
-#<disabled_v4>Include = /etc/pacman.d/cachyos-v4-mirrorlist
-
-#<disabled_v3>[cachyos-v3]
-#<disabled_v3>Include = /etc/pacman.d/cachyos-v3-mirrorlist
-
-#<disabled_v3>[cachyos-core-v3]
-#<disabled_v3>Include = /etc/pacman.d/cachyos-v3-mirrorlist
-
-#<disabled_v3>[cachyos-extra-v3]
-#<disabled_v3>Include = /etc/pacman.d/cachyos-v3-mirrorlist
-
 [cachyos]
 Include = /etc/pacman.d/cachyos-mirrorlist
 


### PR DESCRIPTION
It was needed only by old try-v3 script. New detect-architecture adds extra repositories on top of existing `cachyos` repository.